### PR TITLE
update credentialsrequest from v1beta1 to v1

### DIFF
--- a/manifests/00-ingress-credentials-request.yaml
+++ b/manifests/00-ingress-credentials-request.yaml
@@ -1,4 +1,4 @@
-apiVersion: cloudcredential.openshift.io/v1beta1
+apiVersion: cloudcredential.openshift.io/v1
 kind: CredentialsRequest
 metadata:
   labels:


### PR DESCRIPTION
to avoid the CVO repeatedly applying the v1beta1 version of the CredentialsRequest and then having the cloud-cred-operator migrate it to v1 (see https://bugzilla.redhat.com/show_bug.cgi?id=1690069 ), just update the version in the manifests dir to v1 (there are no changes to the object from v1beta1 to v1)